### PR TITLE
Making changes to satisfy flake8 and minimum device size.

### DIFF
--- a/functional_tests/test_zfs.py
+++ b/functional_tests/test_zfs.py
@@ -18,7 +18,7 @@ class TestZfs(unittest.TestCase):
         self.mount_point = tempfile.mkdtemp()
         self.devices = []
         print('Creating files in {0}'.format(self.directory))
-        # The command to create multiple images to mount zfs minimu 64MB.
+        # The command to create multiple images to mount zfs minimum of 64MB.
         image = 'dd if=/dev/zero of={0} bs=1024 count=65536'
         for a in range(6):
             output_file = '{0}/zfs{1}.img'.format(self.directory, str(a))

--- a/functional_tests/test_zfs.py
+++ b/functional_tests/test_zfs.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import sys
 import tempfile
 import unittest
 
@@ -19,8 +18,8 @@ class TestZfs(unittest.TestCase):
         self.mount_point = tempfile.mkdtemp()
         self.devices = []
         print('Creating files in {0}'.format(self.directory))
-        # The command to create multiple images to mount zfs.
-        image = 'dd if=/dev/zero of={0} bs=1024 count=150'
+        # The command to create multiple images to mount zfs minimu 64MB.
+        image = 'dd if=/dev/zero of={0} bs=1024 count=65536'
         for a in range(6):
             output_file = '{0}/zfs{1}.img'.format(self.directory, str(a))
             print(image.format(output_file))
@@ -45,7 +44,7 @@ class TestZfs(unittest.TestCase):
         destroy = 'sudo zpool destroy -f {0}'.format(pool.pool_name)
         check_call(split(destroy))
         print('Pool {0} destroyed.'.format(pool.pool_name))
-        assert pool.pool_name in output.split()[0], 'Pool name not in zfs pool listing.'
+        assert pool.pool_name in output.split()[0], 'Pool name not in zfs pool listing.'  # noqa
 
     def test_create(self):
         '''Test the create path to create a ZfsPool.'''
@@ -60,7 +59,7 @@ class TestZfs(unittest.TestCase):
         destroy = 'sudo zpool destroy -f {0}'.format(pool.pool_name)
         check_call(split(destroy))
         print('Pool {0} destroyed.'.format(pool.pool_name))
-        assert pool.pool_name in output.split()[0], 'Pool name not in zfs pool listing.'
+        assert pool.pool_name in output.split()[0], 'Pool name not in zfs pool listing.'  # noqa
 
     def tearDown(self):
         '''Operations run once at the end of the tests.'''

--- a/lib/zfs.py
+++ b/lib/zfs.py
@@ -49,10 +49,11 @@ class ZfsPool(StoragePool):
         cmd = 'sudo zfs list -H {0}'.format(self.pool_name)
         output = check_output(split(cmd))
         if output:
-            # NAME           USED  AVAIL  REFER  MOUNTPOINT
-            # mbruzek-pool  62.5K   688M    19K  /mbruzek-pool
-            self.used = str(line.split()[1])
-            self.total = str(line.split()[2])
+            line = output.split()
+            # NAME    USED    AVAIL   REFER   MOUNTPOINT
+            # line[0] line[1] line[2] line[3] line[4]
+            self.used = str(line[1])
+            self.total = str(line[2])
         # Return a tuple of used and available for this pool.
         return self.used, self.total
 


### PR DESCRIPTION
Running bundletester revealed some errors in the built layer.

```
cannot create 'juju-zfs-pool': one or more devices is less than the minimum size (64M)
```
