### PR TITLE
Fixing flake8 complaint.

### DIFF
--- a/lib/zfs.py
+++ b/lib/zfs.py
@@ -78,7 +78,7 @@ class ZfsPool(StoragePool):
                     self.pool_name)
             cmd += ' '.join(devices)
             print(cmd)
-            output = check_output(split(cmd))
+            check_call(split(cmd))
             self.devices = devices
 
     @staticmethod


### PR DESCRIPTION
The kubernetes charm fails flake8 because of the variable output never used. Fixing flake8 issues in all the layers.
